### PR TITLE
Fix lint CI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [0.0.3] 28 Jan 2020
+
+### Fixed
+  - Python 2 compatibility (and CI linting step)
+  - Python 3 CI step
+
+## [0.0.2] 05 Dec 2019
+
+### Changed
+  - Refactor actions to use lib/base.py
+
 ## [0.0.1] 16 Nov 2019
 
 ### Added

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 class PowerDNSClient(Action):
     def __init__(self, config, timeout=5):
-        super().__init__(config)
+        super(PowerDNSClient, self).__init__(config)
         self.api_key = config.get("api_key")
         self.api_url = config.get("api_url")
         self.api_client = None
@@ -22,7 +22,7 @@ class PowerDNSClient(Action):
         self.current_zone = None
 
     def run(self, timeout):
-        super().run()
+        super(PowerDNSClient, self).run()
         self.api_client = powerdns.PDNSApiClient(
             api_endpoint=self.api_url,
             api_key=self.api_key,
@@ -52,17 +52,8 @@ class PowerDNSClient(Action):
         self.select_server(server_id)
         return self.current_server.get_zone(name)
 
-    def zone_create(
-        self,
-        server_id,
-        name,
-        kind,
-        nameservers,
-        masters=None,
-        servers=None,
-        rrsets=None,
-        update=False
-    ):
+    def zone_create(self, server_id, name, kind, nameservers, masters=None, servers=None,
+                    rrsets=None, update=False):
         self.select_server(server_id)
         return self.current_server.create_zone(
             name,

--- a/actions/servers_list.py
+++ b/actions/servers_list.py
@@ -6,5 +6,5 @@ class ServerList(PowerDNSClient):
     List available PowerDNS servers.
     """
     def run(self, response_timeout=5):
-        super().run(response_timeout)
+        super(ServerList, self).run(response_timeout)
         return (True, self.servers_list())

--- a/actions/zone_create.py
+++ b/actions/zone_create.py
@@ -5,19 +5,8 @@ class ZoneCreate(PowerDNSClient):
     """
     Create a new zone.
     """
-    def run(
-        self,
-        server_id,
-        name,
-        nameservers,
-        kind,
-        soa,
-        rr_name,
-        rtype,
-        ttl,
-        response_timeout=5
-    ):
-        super().run(response_timeout)
+    def run(self, server_id, name, nameservers, kind, soa, rr_name, rtype, ttl, response_timeout=5):
+        super(ZoneCreate, self).run(response_timeout)
         return (
             True,
             self.zone_create(

--- a/actions/zone_delete.py
+++ b/actions/zone_delete.py
@@ -6,5 +6,5 @@ class ZoneDelete(PowerDNSClient):
     Delete a zone by name.
     """
     def run(self, server_id, name, response_timeout=5):
-        super().run(response_timeout)
+        super(ZoneDelete, self).run(response_timeout)
         return (True, self.zone_delete(server_id, name))

--- a/actions/zone_details.py
+++ b/actions/zone_details.py
@@ -6,5 +6,5 @@ class ZoneDetails(PowerDNSClient):
     Get a zone details.
     """
     def run(self, server_id, name, response_timeout=5):
-        super().run(response_timeout)
+        super(ZoneDetails, self).run(response_timeout)
         return (True, self.zone_details(server_id, name))

--- a/actions/zone_get.py
+++ b/actions/zone_get.py
@@ -6,5 +6,5 @@ class ZoneGet(PowerDNSClient):
     Get a zone by name.
     """
     def run(self, server_id, name, response_timeout=5):
-        super().run(response_timeout)
+        super(ZoneGet, self).run(response_timeout)
         return (True, self.zone_get(server_id, name))

--- a/actions/zones_list.py
+++ b/actions/zones_list.py
@@ -6,5 +6,5 @@ class ZonesList(PowerDNSClient):
     List zones.
     """
     def run(self, server_id, response_timeout=5):
-        super().run(response_timeout)
+        super(ZonesList, self).run(response_timeout)
         return (True, self.zones_list(server_id))

--- a/actions/zones_search.py
+++ b/actions/zones_search.py
@@ -6,5 +6,5 @@ class ZonesSearch(PowerDNSClient):
     Search for a term in all zones on the server.
     """
     def run(self, server_id, search_term, max_results=50, response_timeout=5):
-        super().run(response_timeout)
-        return (True, self.search(server_id, search_term, max_results))
+        super(ZonesSearch, self).run(response_timeout)
+        return (True, self.zones_search(server_id, search_term, max_results))

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 name: powerdns
 description: StackStorm intergratation for the PowerDNS API.
-version: 0.0.2
+version: 0.0.3
 author: Carlos
 email: nzlosh@yahoo.com
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,3 +4,6 @@ description: StackStorm intergratation for the PowerDNS API.
 version: 0.0.2
 author: Carlos
 email: nzlosh@yahoo.com
+python_versions:
+  - "2"
+  - "3"


### PR DESCRIPTION
Fix CI lint step (mostly just making sure Python 3's `super()` just used Python 2's `super(..., self)`) and turn on Python 3 in weekend CI checks by noting supported Python versions to `pack.yaml`.